### PR TITLE
fix: wrap errors for caller to investigate

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -2,7 +2,6 @@ package nordigen
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -104,7 +103,7 @@ func (c Client) GetAccountMetadata(id string) (AccountMetadata, error) {
 		return AccountMetadata{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return AccountMetadata{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return AccountMetadata{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	accMtdt := AccountMetadata{}
 	err = json.Unmarshal(body, &accMtdt)
@@ -134,7 +133,7 @@ func (c Client) GetAccountBalances(id string) (AccountBalances, error) {
 		return AccountBalances{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return AccountBalances{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return AccountBalances{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	accBlnc := AccountBalances{}
 	err = json.Unmarshal(body, &accBlnc)
@@ -164,7 +163,7 @@ func (c Client) GetAccountDetails(id string) (AccountDetails, error) {
 		return AccountDetails{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return AccountDetails{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return AccountDetails{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	accDtl := AccountDetails{}
 	err = json.Unmarshal(body, &accDtl)
@@ -194,7 +193,7 @@ func (c Client) GetAccountTransactions(id string) (AccountTransactions, error) {
 		return AccountTransactions{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return AccountTransactions{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return AccountTransactions{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	accTxns := AccountTransactions{}
 	err = json.Unmarshal(body, &accTxns)

--- a/agreements.go
+++ b/agreements.go
@@ -3,7 +3,6 @@ package nordigen
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -51,7 +50,7 @@ func (c Client) CreateEndUserAgreement(eua EndUserAgreement) (EndUserAgreement, 
 		return EndUserAgreement{}, err
 	}
 	if resp.StatusCode != http.StatusCreated {
-		return EndUserAgreement{}, fmt.Errorf("expected %d status code: got %d", http.StatusCreated, resp.StatusCode)
+		return EndUserAgreement{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	err = json.Unmarshal(body, &eua)
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,17 @@
+package nordigen
+
+import "fmt"
+
+type APIError struct {
+	StatusCode int
+	Body       string
+	Err        error
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("APIError %v %v", e.StatusCode, e.Body)
+}
+
+func (e *APIError) Unwrap() error {
+	return e.Err
+}

--- a/institutions.go
+++ b/institutions.go
@@ -2,7 +2,6 @@ package nordigen
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -43,7 +42,7 @@ func (c Client) ListInstitutions(country string) ([]Institution, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return nil, &APIError{resp.StatusCode, string(body), err}
 	}
 	list := make([]Institution, 0)
 	err = json.Unmarshal(body, &list)
@@ -73,7 +72,7 @@ func (c Client) GetInstitution(institutionID string) (Institution, error) {
 		return Institution{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return Institution{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return Institution{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	insttn := Institution{}
 	err = json.Unmarshal(body, &insttn)

--- a/requisitions.go
+++ b/requisitions.go
@@ -3,7 +3,6 @@ package nordigen
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -61,7 +60,7 @@ func (c Client) CreateRequisition(r Requisition) (Requisition, error) {
 		return Requisition{}, err
 	}
 	if resp.StatusCode != http.StatusCreated {
-		return Requisition{}, fmt.Errorf("expected %d status code: got %d", http.StatusCreated, resp.StatusCode)
+		return Requisition{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	err = json.Unmarshal(body, &r)
 
@@ -91,7 +90,7 @@ func (c Client) GetRequisition(id string) (r Requisition, err error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return Requisition{}, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return Requisition{}, &APIError{resp.StatusCode, string(body), err}
 	}
 	err = json.Unmarshal(body, &r)
 

--- a/token.go
+++ b/token.go
@@ -3,7 +3,6 @@ package nordigen
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -32,8 +31,8 @@ func (c Client) newToken(secretId, secretKey string) (*Token, error) {
 		Method: http.MethodPost,
 		URL: &url.URL{
 			Scheme: "https",
-			Host: baseUrl,
-			Path: strings.Join([]string{apiPath, tokenPath, tokenNewPath}, "/"),
+			Host:   baseUrl,
+			Path:   strings.Join([]string{apiPath, tokenPath, tokenNewPath}, "/"),
 		},
 	}
 	req.Header = http.Header{}
@@ -59,7 +58,7 @@ func (c Client) newToken(secretId, secretKey string) (*Token, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return nil, &APIError{resp.StatusCode, string(body), err}
 	}
 	t := &Token{}
 	err = json.Unmarshal(body, &t)
@@ -96,7 +95,7 @@ func (c Client) refreshToken(refresh string) (*Token, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected %d status code: got %d", http.StatusOK, resp.StatusCode)
+		return nil, &APIError{resp.StatusCode, string(body), err}
 	}
 	t := &Token{}
 	err = json.Unmarshal(body, &t)


### PR DESCRIPTION
* The caller of this library cant see the HTTP response body of the
  error if any of the calls fail, and thus in most cases are in the
  blind of why it fails. This adds a APIError type that implements the
  Error and Unwrap interfaces. For example changing the error message
  from: `expected 200 status code: got 400` to `APIError 400
  {"summary":"foo","status_code":400}`