### PR TITLE
Add optional `date_from` `date_to` query params to `GetAccountTransactions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ func main() {
 	blnc, err := c.GetAccountBalances(r.Accounts[0])
 	
 	//get accounts transactions
-	txns, err := c.GetAccountTransactions(r.Accounts[0].Id)
+	txns, err := c.GetAccountTransactions(r.Accounts[0].Id, nil, nil)
 
+	//get previous week accounts transactions
+	from := &time.Now().Add(-14 * 24 * time.Hour)
+	to := &time.Now().Add(-7 * 24 * time.Hour)
+	txns, err := c.GetAccountTransactions(r.Accounts[0].Id, from, to)
 }
 
 func GetAuthorization(cli nordigen.Client, bankId string, endUserId string) (nordigen.Requisition, error) {

--- a/accounts.go
+++ b/accounts.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type AccountMetadata struct {
@@ -175,13 +176,15 @@ func (c Client) GetAccountDetails(id string) (AccountDetails, error) {
 	return accDtl, nil
 }
 
-func (c Client) GetAccountTransactions(id string) (AccountTransactions, error) {
+func (c Client) GetAccountTransactions(id string, from, to *time.Time) (AccountTransactions, error) {
 	req := http.Request{
 		Method: http.MethodGet,
 		URL: &url.URL{
-			Path: strings.Join([]string{accountPath, id, transactionsPath, ""}, "/"),
+			Path:     strings.Join([]string{accountPath, id, transactionsPath, ""}, "/"),
+			RawQuery: dateParams(from, to),
 		},
 	}
+
 	resp, err := c.c.Do(&req)
 
 	if err != nil {
@@ -203,4 +206,15 @@ func (c Client) GetAccountTransactions(id string) (AccountTransactions, error) {
 	}
 
 	return accTxns, nil
+}
+
+func dateParams(from, to *time.Time) string {
+	params := url.Values{}
+	if from != nil {
+		params.Add("date_from", from.Format("2006-01-02"))
+	}
+	if to != nil {
+		params.Add("date_to", to.Format("2006-01-02"))
+	}
+	return params.Encode()
 }


### PR DESCRIPTION
Thanks for the work done in this library!

Here is a proposal to handle the `date_from`, `date_to` query parameters allowing to fetch transactions in a given time range.