### PR TITLE
Add the internal transaction ID field to transactions

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -68,6 +68,7 @@ type Transaction struct {
 	RemittanceInformationUnstructuredArray []string `json:"RemittanceInformationUnstructuredArray"`
 	BankTransactionCode                    string   `json:"bankTransactionCode,omitempty"`
 	AdditionalInformation                  string   `json:"additionalInformation,omitempty"`
+	InternalTransactionId                  string   `json:"internalTransactionId,omitempty"`
 }
 
 type AccountTransactions struct {


### PR DESCRIPTION
This is useful for matching transactions among multiple transaction calls.This is useful for matching transactions among multiple
transaction calls.