### PR TITLE
Added BookingDateTime missing field in Transaction struct

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -49,6 +49,7 @@ type Transaction struct {
 	TransactionId     string `json:"transactionId,omitempty"`
 	EntryReference    string `json:"entryReference,omitempty"`
 	BookingDate       string `json:"bookingDate,omitempty"`
+	BookingDateTime       string `json:"bookingDateTime,omitempty"`
 	ValueDate         string `json:"valueDate,omitempty"`
 	TransactionAmount struct {
 		Amount   string `json:"amount,omitempty"`


### PR DESCRIPTION
Hello,
I started using this library recently and I noticed that in the Transaction struct there is no Time attribute, while Nordigen API is providing it in "bookingDateTime" field.
This is just a small PR to add this very important field

Thank you and great job!