### PR TITLE
Update baseURL to bankaccountdata.gocardless.com

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const baseUrl = "ob.nordigen.com"
+const baseUrl = "bankaccountdata.gocardless.com"
 const apiPath = "/api/v2"
 
 type Client struct {


### PR DESCRIPTION
GoCardless are decommisioning the `ob.nordigen.com` address on 2024-02-20

This updates the baseURL to the correct one.

As per a recent email from GoCardless

> We are contacting you to make sure you are using an up-to-date base_url for the GoCardless Bank Account Data API.
This small but important change which should be easy to make for anyone in your team who has access to the production setup of your service. The new connection string should be:
https://bankaccountdata.gocardless.com/api/v2/
>
> The legacy URLs such as [ob.nordigen.com](http://ob.nordigen.com/) and [ob.gocardless.com](http://ob.gocardless.com/) will stop working on the 20th of February.