### PR TITLE
fix: token is invalid or expired

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,7 +22,7 @@ func TestClientTokenRefresh(t *testing.T) {
 		t.Fatalf("NewClient: %s", err)
 	}
 
-	c.expiration = time.Now().Add(-time.Hour)
+	c.nextRefresh = time.Now().Add(-time.Hour)
 	_, err = c.ListRequisitions()
 	if err != nil {
 		t.Fatalf("ListRequisitions: %s", err)

--- a/token.go
+++ b/token.go
@@ -2,6 +2,7 @@ package nordigen
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -16,6 +17,10 @@ type Token struct {
 	RefreshExpires int    `json:"refresh_expires"`
 }
 
+type TokenRefresh struct {
+	Refresh string `json:"refresh"`
+}
+
 type Secret struct {
 	SecretId string `json:"secret_id"`
 	AccessId string `json:"secret_key"`
@@ -23,16 +28,9 @@ type Secret struct {
 
 const tokenPath = "token"
 const tokenNewPath = "new/"
-const tokenRefreshPath = "refresh"
+const tokenRefreshPath = "refresh/"
 
-func (c Client) newToken() (*Token, error) {
-	req := http.Request{
-		Method: http.MethodPost,
-		URL: &url.URL{
-			Path: strings.Join([]string{tokenPath, tokenNewPath}, "/"),
-		},
-	}
-
+func (c Client) newToken(ctx context.Context) (*Token, error) {
 	data, err := json.Marshal(Secret{
 		SecretId: c.secretId,
 		AccessId: c.secretKey,
@@ -40,63 +38,69 @@ func (c Client) newToken() (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(data))
-	resp, err := c.c.Do(&req)
 
+	req := &http.Request{
+		Method: http.MethodPost,
+		Body:   io.NopCloser(bytes.NewBuffer(data)),
+		URL: &url.URL{
+			Path: strings.Join([]string{tokenPath, tokenNewPath}, "/"),
+		},
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
 
-	if err != nil {
-		return nil, err
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, readErr
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, &APIError{resp.StatusCode, string(body), err}
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
-	t := &Token{}
-	err = json.Unmarshal(body, &t)
 
-	if err != nil {
+	t := &Token{}
+	if err := json.Unmarshal(body, t); err != nil {
 		return nil, err
 	}
-
 	return t, nil
 }
 
-func (c Client) refreshToken(refresh string) (*Token, error) {
-	req := http.Request{
+func (c Client) refreshToken(ctx context.Context, refresh string) (*Token, error) {
+	data, err := json.Marshal(TokenRefresh{Refresh: refresh})
+	if err != nil {
+		return nil, err
+	}
+
+	req := &http.Request{
 		Method: http.MethodPost,
+		Body:   io.NopCloser(bytes.NewBuffer(data)),
 		URL: &url.URL{
 			Path: strings.Join([]string{tokenPath, tokenRefreshPath}, "/"),
 		},
 	}
-	data, err := json.Marshal(refresh)
+	req = req.WithContext(ctx)
 
-	if err != nil {
-		return &Token{}, err
-	}
-	req.Body = io.NopCloser(bytes.NewBuffer(data))
-
-	resp, err := c.c.Do(&req)
-
+	resp, err := c.c.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	body, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
 
-	if err != nil {
-		return nil, err
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, readErr
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, &APIError{resp.StatusCode, string(body), err}
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
-	t := &Token{}
-	err = json.Unmarshal(body, &t)
 
-	if err != nil {
+	t := &Token{}
+	if err := json.Unmarshal(body, t); err != nil {
 		return nil, err
 	}
-
 	return t, nil
 }


### PR DESCRIPTION
The refresh goroutine was stopped immediately after starting, fix that logic error to refresh the token in the background after half the access token lifetime.

Fixes martinohansen/ynabber#97