### PR TITLE
fix: 401 invalid token

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -32,12 +32,11 @@ func initTestClient(t *testing.T) *Client {
 		c.c.Transport = Transport{rt: http.DefaultTransport, cli: c}
 
 		// Initialize the first token
-		token, err := c.newToken(context.Background())
+		err := c.newToken(context.Background())
 		if err != nil {
 			t.Fatalf("newToken: %s", err)
 		}
 
-		c.token = token
 		sharedClient = c
 	})
 


### PR DESCRIPTION
The API returns an empty refresh token when a refresh call is made, causing subsequent calls to fail. This is fixed by updating the token with just the new access token and expiration time.